### PR TITLE
Prepare for upcoming change to File.openRead()

### DIFF
--- a/lib/zip/zip_package.dart
+++ b/lib/zip/zip_package.dart
@@ -97,7 +97,7 @@ class ZipPackage {
     final int end,
     final int compressionMethod,
   }) {
-    final stream = file.openRead(start, end);
+    final stream = file.openRead(start, end).cast<List<int>>();
     if (compressionMethod == 0) return stream;
     if (compressionMethod == 8) return stream.transform(zlibDecoder);
 
@@ -105,7 +105,7 @@ class ZipPackage {
   }
 
   static Stream<List<int>> raw(File file, {final int start, final int end}) =>
-      file.openRead(start, end);
+      file.openRead(start, end).cast<List<int>>();
 
   Stream<List<int>> extractStream(String filename) {
     final zip = entries[filename];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: epub_package
 description: A new Flutter package project.
-version: 0.0.3-beta3
+version: 0.0.3-beta4
 author: eGust<egustc@gmail.com>
 homepage: https://github.com/eGust/epub-package.dart
 


### PR DESCRIPTION
An upcoming change to the Dart SDK will change the signature
of `File.openRead()` from returning `Stream<List<int>>` to
returning `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900